### PR TITLE
v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,11 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f4ae4e302a80591635ef9a236b35fde6fcc26cfd060e66fde4ba9f9fd394a1"
+checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
 dependencies = [
+ "serde",
+ "serde_json",
  "wit-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/biome.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.5"
+zed_extension_api = "0.0.6"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This extension adds support for [Biome](https://github.com/biomejs/biome) in [Zed](https://zed.dev/).
 
+Currently supports **JavaScript**, **TypeScript**, **TSX**, **Vue.js**, **Astro** and **Svelte** files.
+
+## Installtion
+
+Requires Zed >= **v0.131.0**.
+
+This extension is available in the extensions view inside the Zed editor. Open `zed: extensions` and search for _Biome_.
+
+### Development
+
+1. Clone this repository.
+2. Run the `zed: install dev extensions` command.
+3. Select the directory of this repo.
+
 ## Configuration
 
 Example configurations in zed `settings.json`.

--- a/extension.toml
+++ b/extension.toml
@@ -1,23 +1,12 @@
 id = "biome"
 name = "Biome"
 description = "Biome support for Zed"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["biomejs <biomejs.dev>"]
 repository = "https://github.com/biomejs/biome-zed"
 
 [language_servers.biome]
 name = "Biome Language Server"
-language = "JavaScript"
-language_ids = { "JavaScript" = "javascript" }
-
-# cant register a single one for multiple langs yet
-[language_servers.biome_ts]
-name = "Biome Language Server"
-language = "TypeScript"
-language_ids = { "TypeScript" = "typescript" }
-
-[language_servers.biome_tsx]
-name = "Biome Language Server"
-language = "TSX"
-language_ids = { "TSX" = "typescriptreact" }
+languages = ["JavaScript", "JSX", "TypeScript", "TSX", "JSON"]
+language_ids = { "JavaScript" = "javascript", "JSX" = "javascriptreact", "TypeScript" = "typescript", "TSX" = "typescriptreact", "JSON" = "json" }

--- a/extension.toml
+++ b/extension.toml
@@ -8,5 +8,21 @@ repository = "https://github.com/biomejs/biome-zed"
 
 [language_servers.biome]
 name = "Biome Language Server"
-languages = ["JavaScript", "JSX", "TypeScript", "TSX", "JSON"]
-language_ids = { "JavaScript" = "javascript", "JSX" = "javascriptreact", "TypeScript" = "typescript", "TSX" = "typescriptreact", "JSON" = "json" }
+languages = [
+    "JavaScript",
+    "JSX",
+    "TypeScript",
+    "TSX",
+    "Vue.js",
+    "Astro",
+    "Svelte",
+]
+
+[language_ids]
+"JavaScript" = "javascript"
+"JSX" = "javascriptreact"
+"TypeScript" = "typescript"
+"TSX" = "typescriptreact"
+"Vue.js" = "vuejs"
+"Astro" = "astro"
+"Svelte" = "svelte"

--- a/src/biome.rs
+++ b/src/biome.rs
@@ -5,81 +5,82 @@ const SERVER_PATH: &str = "node_modules/.bin/biome";
 const PACKAGE_NAME: &str = "@biomejs/biome";
 
 struct BiomeExtension {
-    did_find_server: bool,
+  did_find_server: bool,
 }
 
 impl BiomeExtension {
-    fn server_exists(&self) -> bool {
-        fs::metadata(SERVER_PATH).map_or(false, |stat| stat.is_file())
+  fn server_exists(&self) -> bool {
+    fs::metadata(SERVER_PATH).map_or(false, |stat| stat.is_file())
+  }
+
+  fn server_script_path(&mut self, ls_id: &zed::LanguageServerId) -> Result<String> {
+    let server_exists = self.server_exists();
+    if self.did_find_server && server_exists {
+      return Ok(SERVER_PATH.to_string());
     }
 
-    fn server_script_path(&mut self, config: zed::LanguageServerConfig) -> Result<String> {
-        let server_exists = self.server_exists();
-        if self.did_find_server && server_exists {
-            return Ok(SERVER_PATH.to_string());
+    zed::set_language_server_installation_status(
+      ls_id,
+      &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+    );
+    let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
+
+    if !server_exists
+      || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)
+    {
+      zed::set_language_server_installation_status(
+        &ls_id,
+        &zed::LanguageServerInstallationStatus::Downloading,
+      );
+      let result = zed::npm_install_package(PACKAGE_NAME, &version);
+      match result {
+        Ok(()) => {
+          if !self.server_exists() {
+            Err(format!(
+              "installed package '{PACKAGE_NAME}' did not contain expected path '{SERVER_PATH}'",
+            ))?;
+          }
         }
-
-        zed::set_language_server_installation_status(
-            &config.name,
-            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-        );
-        let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
-
-        if !server_exists
-            || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)
-        {
-            zed::set_language_server_installation_status(
-                &config.name,
-                &zed::LanguageServerInstallationStatus::Downloading,
-            );
-            let result = zed::npm_install_package(PACKAGE_NAME, &version);
-            match result {
-                Ok(()) => {
-                    if !self.server_exists() {
-                        Err(format!(
-                            "installed package '{PACKAGE_NAME}' did not contain expected path '{SERVER_PATH}'",
-                        ))?;
-                    }
-                }
-                Err(error) => {
-                    if !self.server_exists() {
-                        Err(error)?;
-                    }
-                }
-            }
+        Err(error) => {
+          if !self.server_exists() {
+            Err(error)?;
+          }
         }
-
-        self.did_find_server = true;
-        Ok(SERVER_PATH.to_string())
+      }
     }
+
+    self.did_find_server = true;
+    Ok(SERVER_PATH.to_string())
+  }
 }
 
 impl zed::Extension for BiomeExtension {
-    fn new() -> Self {
-        Self {
-            did_find_server: false,
-        }
+  fn new() -> Self {
+    Self {
+      did_find_server: false,
     }
+  }
 
-    fn language_server_command(
-        &mut self,
-        config: zed::LanguageServerConfig,
-        _worktree: &zed::Worktree,
-    ) -> Result<zed::Command> {
-        let server_path = self.server_script_path(config)?;
-        Ok(zed::Command {
-            command: zed::node_binary_path()?,
-            args: vec![
-                env::current_dir()
-                    .unwrap()
-                    .join(&server_path)
-                    .to_string_lossy()
-                    .to_string(),
-                "lsp-proxy".to_string(),
-            ],
-            env: Default::default(),
-        })
-    }
+  fn language_server_command(
+    &mut self,
+    language_server_id: &zed::LanguageServerId,
+    _worktree: &zed::Worktree,
+  ) -> Result<zed::Command> {
+    let path = self.server_script_path(&language_server_id)?;
+
+    Ok(zed::Command {
+      command: zed::node_binary_path()?,
+      args: vec![
+        env::current_dir()
+          .unwrap()
+          .join(&path)
+          .to_string_lossy()
+          .to_string(),
+        "lsp-proxy".to_string(),
+      ],
+      env: Default::default(),
+    })
+  }
 }
 
 zed::register_extension!(BiomeExtension);


### PR DESCRIPTION
## Changes
- Bump zed_extension_api to 0.0.6
- Support for **Vue.js**, **Astro** and **Svelte** files

## Preconditions
- [ ] Zed **v0.131.0** is released