### PR TITLE
Fix nesting of `language_ids`

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -18,7 +18,7 @@ languages = [
     "Svelte",
 ]
 
-[language_ids]
+[language_servers.biome.language_ids]
 "JavaScript" = "javascript"
 "JSX" = "javascriptreact"
 "TypeScript" = "typescript"


### PR DESCRIPTION
This PR fixes the nesting of the `language_ids` field so it is underneath the `biome` language server entry.

The current top-level `language_ids` is not valid according to the extension manifest schema: https://github.com/zed-industries/zed/blob/b6857ca469293112a89784817fba0685b1553892/crates/extension/src/extension_manifest.rs#L107-L108
