### PR TITLE
Update `source.organizeImports` config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example configurations in zed `settings.json`.
   "format_on_save": "on",
   "code_actions_on_format": {
     "source.fixAll": true,
-    "source.organizeImports": true
+    "source.organizeImports.biome": true
   },
   "formatter": {
     "external": {


### PR DESCRIPTION
Change `source.organizeImports` to `source.organizeImports.biome` in the configuration example.

Using `source.organizeImports` will use the primary lsp to format the imports, instead, we can use biome lsp to format the imports with `source.organizeImports.biome`