### PR TITLE
feat: add support to configure `--config-path` through settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This extension is available in the extensions view inside the Zed editor. Open `
 
 Run code actions on format:
 
-```json5
+```jsonc
 // settings.json
 {
   "code_actions_on_format": {
@@ -51,7 +51,7 @@ Run code actions on format:
 
 Configure the `--config-path` flag for the language server:
 
-```json5
+```jsonc
 // settings.json
 {
   "lsp": {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This extension is available in the extensions view inside the Zed editor. Open `
 
 Run code actions on format:
 
-```jsonc
+```json5
 // settings.json
 {
   "code_actions_on_format": {
@@ -51,7 +51,7 @@ Run code actions on format:
 
 Configure the `--config-path` flag for the language server:
 
-```jsonc
+```json5
 // settings.json
 {
   "lsp": {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
     </picture>
 </p>
 
-
 <div align="center">
 
 [![CI main](https://github.com/biomejs/biome-zed/actions/workflows/main.yml/badge.svg)](https://github.com/biomejs/biome-zed/actions/workflows/main.yml)
@@ -38,16 +37,29 @@ This extension is available in the extensions view inside the Zed editor. Open `
 
 ## Configuration
 
-Example configurations in zed `settings.json`.
+Run code actions on format:
 
-```json5
+```jsonc
 // settings.json
 {
-  "format_on_save": "on",
   "code_actions_on_format": {
-    "source.fixAll": true,
+    "source.fixAll.biome": true,
     "source.organizeImports.biome": true
-  },
-  "formatter": "language_server"
+  }
+}
+```
+
+Configure the `--config-path` flag for the language server:
+
+```jsonc
+// settings.json
+{
+  "lsp": {
+    "biome": {
+      "settings": {
+        "config_path": "<path>/biome.json"
+      }
+    }
+  }
 }
 ```

--- a/src/biome.rs
+++ b/src/biome.rs
@@ -99,9 +99,7 @@ impl zed::Extension for BiomeExtension {
     ];
 
     if let Some(settings) = settings.settings {
-      let config_path = settings
-        .get("config_path")
-        .map(|value| value.as_str().unwrap());
+      let config_path = settings.get("config_path").and_then(|value| value.as_str());
 
       if let Some(path) = config_path {
         args.push("--config-path".to_string());

--- a/src/biome.rs
+++ b/src/biome.rs
@@ -101,7 +101,6 @@ impl zed::Extension for BiomeExtension {
     if let Some(settings) = settings.settings {
       let config_path = settings
         .get("config_path")
-        .clone()
         .map(|value| value.as_str().unwrap());
 
       if let Some(path) = config_path {

--- a/src/biome.rs
+++ b/src/biome.rs
@@ -89,7 +89,7 @@ impl zed::Extension for BiomeExtension {
     let path = self.server_script_path(language_server_id, worktree)?;
     let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
 
-    let args = vec![
+    let mut args = vec![
       env::current_dir()
         .unwrap()
         .join(path)
@@ -97,6 +97,18 @@ impl zed::Extension for BiomeExtension {
         .to_string(),
       "lsp-proxy".to_string(),
     ];
+
+    if let Some(settings) = settings.settings {
+      let config_path = settings
+        .get("config_path")
+        .clone()
+        .map(|value| value.as_str().unwrap());
+
+      if let Some(path) = config_path {
+        args.push("--config-path".to_string());
+        args.push(path.to_string());
+      }
+    }
 
     if let Some(binary) = settings.binary {
       return Ok(zed::Command {


### PR DESCRIPTION
Adds configuration options for `--config-path flag. 
Resolves https://github.com/biomejs/biome-zed/issues/20