### PR TITLE
fix: biome installed with pnpm fails to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 extension.wasm
+node_modules
+package-lock.json
+pnpm-lock.yaml
+package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
-# Changelog 
+# Changelog
+
+## 0.1.1 (2024-07-25)
+
+### Fixes
+
+- biome installed with pnpm fails to start
+
+## 0.1.0 (2024-07-24)
+
+### Features
+
+- use native biome binary without node (#31)
+- add setting require_config_file (#29)
+- add support to configure --config-path through settings (#23)
+
+## 0.0.7 (2024-06-06)
+
+### Features
+
+- use lsp settings to configure custom biome binary (#19)
+- add support for the CSS language (#17)
 
 ## 0.0.6 (2024-04-22)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,18 +142,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "zed_biome"
-version = "0.0.6"
+version = "0.1.1"
 dependencies = [
  "log",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2021"
 license = "MIT"
 name    = "zed_biome"
 publish = false
-version = "0.0.6"
+version = "0.1.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ id             = "biome"
 name           = "Biome"
 repository     = "https://github.com/biomejs/biome-zed"
 schema_version = 1
-version        = "0.1.0"
+version        = "0.1.1"
 
 [language_servers.biome]
 code_actions_kind = ["", "quickfix"]

--- a/src/biome.rs
+++ b/src/biome.rs
@@ -46,7 +46,7 @@ impl BiomeExtension {
     if local_binary_path.exists() {
       Ok(local_binary_path)
     } else {
-      Err(format!("Error: biome binary not found"))
+      Err("Error: biome binary not found".to_string())
     }
   }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,6 @@
+function test() {
+	return "Hello, world!";
+}
+
+let output = test();
+// This let declares a variable that is only assigned once.

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,6 +1,0 @@
-function test() {
-	return "Hello, world!";
-}
-
-let output = test();
-// This let declares a variable that is only assigned once.


### PR DESCRIPTION
Resolves https://github.com/biomejs/biome-zed/issues/33

With this PR the extension always uses `node_modules/@biomejs/biome/bin/biome` for the worktree. Only when biome is not installed in the project we use the platform specific binary directly.

Note:
In theroy we could use oxc_resolver to find the package with the correct binary, but resolving absolute paths behaves odd in the wasm runtime. Maybe in the future we can do a better job with this.