### PR TITLE
feat: add GraphQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Languages currently supported:
 - **Astro**
 - **Svelte**
 - **CSS**
+- **GraphQL**
 
 ## Installation
 
@@ -35,87 +36,6 @@ Requires Zed >= **v0.131.0**.
 
 This extension is available in the extensions view inside the Zed editor. Open `zed: extensions` and search for _Biome_.
 
-## Configuration
+## Documentation
 
-By default, the biome.json file is required to be in the **root of the workspace**.
-
-Otherwise, it can be configured through the lsp settings:
-
-```jsonc
-// settings.json
-{
-  "lsp": {
-    "biome": {
-      "settings": {
-        "config_path": "<path>/biome.json"
-      }
-    }
-  }
-}
-```
-
-### Formatting
-
-To use the language server as a formatter, specify biome as your formatter in the settings:
-
-```jsonc
-// settings.json
-{
-  "formatter": {
-    "language_server": {
-      "name": "biome"
-    }
-  }
-}
-```
-
-### Enable biome only when biome.json is present
-
-```jsonc
-// settings.json
-{
-  "lsp": {
-    "biome": {
-      "settings": {
-        "require_config_file": true
-      }
-    }
-  }
-}
-```
-
-### Project based configuration
-
-If you'd like to exclude biome from running in every project,
-
-1. Disable the biome language server in user settings:
-
-```jsonc
-// settings.json
-{
-  "language_servers": [ "!biome", "..." ]
-}
-```
-
-2. And enable it in the project's local settings:
-
-```jsonc
-// <workspace>/.zed/settings.json
-{
-  "language_servers": [ "biome", "..." ]
-}
-```
-
-The same can be configured on a per-language basis with the [`languages`](https://zed.dev/docs/configuring-zed#languages) key.
-
-### Run code actions on format:
-
-```jsonc
-// settings.json
-{
-  "code_actions_on_format": {
-    "source.fixAll.biome": true,
-    "source.organizeImports.biome": true
-  }
-}
-```
+Head to the [official documentation](https://biomejs.dev/reference/zed) to learn how to set up the extension, and customize it. 

--- a/extension.toml
+++ b/extension.toml
@@ -4,17 +4,18 @@ id             = "biome"
 name           = "Biome"
 repository     = "https://github.com/biomejs/biome-zed"
 schema_version = 1
-version        = "0.1.2"
+version        = "0.1.3"
 
 [language_servers.biome]
-code_actions_kind = ["", "quickfix"]
+code_actions_kind = ["quickfix"]
 language          = "JavaScript"
-languages         = ["JavaScript", "JSX", "TypeScript", "TSX", "Vue.js", "Astro", "Svelte", "JSON", "JSONC", "CSS"]
+languages         = ["JavaScript", "JSX", "TypeScript", "TSX", "Vue.js", "Astro", "Svelte", "JSON", "JSONC", "CSS", "GraphQL"]
 name              = "Biome Language Server"
 
 [language_servers.biome.language_ids]
 "Astro"      = "astro"
 "CSS"        = "css"
+"GraphQL"    = "graphql"
 "JSON"       = "json"
 "JSONC"      = "jsonc"
 "JSX"        = "javascriptreact"


### PR DESCRIPTION
This PR adds support for GraphQL to Biome.

Plus, it moves the documentation to the website, because that's what we do for the VSCode extension too.