### PR TITLE
fix: rename `code_actions_kind` to `code_action_kinds`

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -7,7 +7,7 @@ schema_version = 1
 version        = "0.1.3"
 
 [language_servers.biome]
-code_actions_kind = ["quickfix"]
+code_action_kinds = ["quickfix"]
 language          = "JavaScript"
 languages         = ["JavaScript", "JSX", "TypeScript", "TSX", "Vue.js", "Astro", "Svelte", "JSON", "JSONC", "CSS", "GraphQL"]
 name              = "Biome Language Server"


### PR DESCRIPTION
Hi, this is a small fix for the extension manifest. The Zed extension manifest does not have field `code_action_kinds` for specifying known code action kinds. This field should be named `code_action_kinds`.
See the Zed's extension manifest by using the link below:

https://github.com/zed-industries/zed/blob/main/crates/extension/src/extension_manifest.rs#L116

Thanks!