### PR TITLE
feat!: remove compatibility for Biome v1

### DIFF
--- a/src/biome.rs
+++ b/src/biome.rs
@@ -122,13 +122,6 @@ impl BiomeExtension {
       .and_then(|value| value.as_bool())
       .unwrap_or(false)
   }
-
-  fn is_biome_v1(&self) -> bool {
-    zed::npm_package_installed_version(PACKAGE_NAME)
-      .ok()
-      .flatten()
-      .is_some_and(|version| version.starts_with("1."))
-  }
 }
 
 impl zed::Extension for BiomeExtension {
@@ -144,17 +137,6 @@ impl zed::Extension for BiomeExtension {
     let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
 
     let mut args = vec!["lsp-proxy".to_string()];
-
-    // evaluate lsp settings for v1 compatibility
-    if self.is_biome_v1() {
-      if let Some(settings) = settings.settings {
-        if let Some(config_path) = self.config_path(worktree, &settings) {
-          args.append(&mut vec!["--config-path".to_string(), config_path.clone()]);
-        } else if self.require_config_file(&settings) {
-          return Err("biome.json is not found but require_config_file is true".to_string());
-        }
-      }
-    }
 
     // check and run biome with custom binary
     if let Some(binary) = settings.binary {


### PR DESCRIPTION
> [!WARNING]
> **Breaking Change**: Using the extension with Biome v1 is no longer supported. Please upgrade to Biome v2, or use older version of the extension.

We tried to keep compatibility for Biome v1 in #77, but it seems not working in some environments. Due to lack of debugging tools in Zed, we decided to just drop the support for Biome v1 and release a new major version.

In this pull request, appending `--config-path` in the LSP command line is no longer supported. If you are using a custom configuration path, it no longer work with Biome v1.