### PR TITLE
feat: support highlighting for code snippets

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -41,4 +41,4 @@ name = "Biome Language Server"
 
 [grammars.gritql]
 repository = "https://github.com/honeycombio/tree-sitter-gritql"
-rev        = "9ffe44d15359476af27f07130807a5ac979e477f"
+rev        = "3a48815250680e85a44b3ab2fd74031ef3c66b7d"

--- a/languages/grit/injections.scm
+++ b/languages/grit/injections.scm
@@ -1,0 +1,19 @@
+; By default, highlight all snippetContent nodes as JavaScript
+((snippetContent) @injection.content
+  (#set! injection.language "javascript"))
+
+
+; The rule below only matches the top-level code snippet before "where"
+; Currently, tree-sitter doesn't have a way to bind the target language
+; to all snippetContent nodes
+; Upstream changes to both tree-sitter and tree-sitter-gritql
+; are needed in order to fully support all CSS code snippets
+
+; Highlight snippetContent as CSS if it's specified
+(source_file
+  language: (langdecl
+    name: (languageName) @injection.language)
+  pattern: (patternWhere
+    pattern: (codeSnippet
+      source: (backtickSnippet
+	      content: (snippetContent) @injection.content))))


### PR DESCRIPTION
By default, it highlights code snippets as JavaScript. When `language css` is declared at the first line, it highlights the top-level code snippet as CSS.

There's a still a limitation for highlighting CSS code snippets as documented in `injections.scm`. I'll explore and propose changes to `tree-sitter` and `tree-sitter-gritql` to support all the scenarios. 

The PR is implemented using guidance from https://zed.dev/docs/extensions/languages#code-injections.

Demos

<details>
<summary>Without code injection</summary>
<img width="1285" height="1321" alt="Screenshot 2025-09-23 at 10 06 54 PM" src="https://github.com/user-attachments/assets/394e7479-d53f-4b26-9c70-6c3d6c764fa5" />
</details>

<details>
<summary>With code injection</summary>
<img width="1300" height="1339" alt="Screenshot 2025-09-23 at 10 01 41 PM" src="https://github.com/user-attachments/assets/b1900e71-4c70-4275-8945-b405e113b0f8" />
</details>

