### PR TITLE
feat: add SVG file support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -22,6 +22,7 @@ languages = [
   "CSS",
   "GraphQL",
   "HTML",
+  "SVG",
 ]
 name = "Biome Language Server"
 
@@ -30,6 +31,7 @@ name = "Biome Language Server"
 "CSS"        = "css"
 "GraphQL"    = "graphql"
 "HTML"       = "html"
+"SVG"        = "svg"
 "JSON"       = "json"
 "JSONC"      = "jsonc"
 "JSX"        = "javascriptreact"


### PR DESCRIPTION
> This PR was written with AI assistance (Claude Code).

## Summary

Add support for `.svg` files in the Zed extension.

## Description

This PR adds `"SVG"` to the list of supported languages and maps it to the `"svg"` language ID so that the Biome language server activates for `.svg` files in Zed.

Changes in `extension.toml`:
- Added `"SVG"` to `language_servers.biome.languages`.
- Added `"SVG" = "svg"` to `language_servers.biome.language_ids`.

## Related

Related to biomejs/biome#9604 and biomejs/biome#9608.